### PR TITLE
Replaced the hardcoded "content" by the var PATH

### DIFF
--- a/liquid.py
+++ b/liquid.py
@@ -33,7 +33,7 @@ def notebook(preprocessor, tag, markup):
     end = int(end) if end else None
 
     # nb_dir =  preprocessor.configs.getConfig('NOTEBOOK_DIR')
-    nb_path = os.path.join('content', src)
+    nb_path = os.path.join(preprocessor.configs.getConfig('PATH'), src)
     content, info = get_html_from_filepath(nb_path, start=start, end=end)
     ignore_css = preprocessor.configs.getConfig('IPYNB_IGNORE_CSS', False)
     content = fix_css(content, info, ignore_css=ignore_css)


### PR DESCRIPTION
Some users don't put their sources into "content". In these cases, the plugin does not work.